### PR TITLE
Potential fix for code scanning alert no. 22: Use of externally-controlled format string

### DIFF
--- a/backend/src/alerts/alerts.service.ts
+++ b/backend/src/alerts/alerts.service.ts
@@ -518,7 +518,7 @@ export class AlertsService {
         }
       } catch (error) {
         console.error(
-          `Error sending push notifications for item ${itemId}:`,
+          'Error sending push notifications for item %s:', itemId,
           error,
         );
         // Ne pas faire échouer la fonction si les notifications échouent


### PR DESCRIPTION
Potential fix for [https://github.com/ogb4n/ShelfSpot/security/code-scanning/22](https://github.com/ogb4n/ShelfSpot/security/code-scanning/22)

The best fix is to ensure that a user-controlled value is not used as a format string in logging statements. For all log and error calls that interpolate untrusted values, you should use format string placeholders (like `%s`, `%d`) and pass the interpolated values as additional arguments, or concatenate the values in a way that avoids ambiguity. In this case, replace the use of template literals that insert `itemId` into the format string in the console logging call on line 521, with a static string containing a `%s` placeholder and pass `itemId` as a separate argument. No imports or additional definitions are needed for this change, just a direct edit to the logging line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
