### PR TITLE
Potential fix for code scanning alert no. 21: Use of externally-controlled format string

### DIFF
--- a/backend/src/alerts/alerts.service.ts
+++ b/backend/src/alerts/alerts.service.ts
@@ -471,7 +471,7 @@ export class AlertsService {
           subject: `🚨 Alerte stock faible - ${alertsToSend[0].item.name} (quantité: ${newQuantity})`,
         });
       } catch (error) {
-        console.error(`Error sending alert emails for item ${itemId}:`, error);
+        console.error('Error sending alert emails for item %s:', itemId, error);
         // Ne pas faire échouer la fonction si l'email échoue
       }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/ogb4n/ShelfSpot/security/code-scanning/21](https://github.com/ogb4n/ShelfSpot/security/code-scanning/21)

To fix this issue, avoid directly embedding any user-controlled value inside a log format string. Instead, pass such values as separate arguments, always using a static log message string and placeholders as necessary (e.g., `'Error sending alert emails for item %s:'` and then passing `itemId` as a separate argument), or simply as additional arguments outside the format string. 

For the specific case on line 474 in `backend/src/alerts/alerts.service.ts`, instead of using a template literal that interpolates `${itemId}` (potentially tainted), change the code to:
```ts
console.error('Error sending alert emails for item %s:', itemId, error);
```
This way, Node.js's `console.error` uses the static string as the format, and the user-controlled value is substituted as a parameter, eliminating any possibility for unintended format string attacks.

No changes are required elsewhere, and no new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
