### PR TITLE
docs: update Swagger schemas and README documentation (FULA-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,68 @@ baked in at image build — rebuild the frontend image whenever you change this 
 
 ---
 
+## Mobile Integration
+
+ShelfSpot sends real-time push notifications to mobile clients via the **Expo Push Notification** service.
+
+### How it works
+
+1. The mobile app (Expo / React Native) calls `PUT /auth/profile/notification-token` after the user logs in, registering its Expo push token with the backend.
+2. When an alert threshold is breached, the backend queries all users who have a stored `notificationToken` and fans out messages through the Expo Push API in batches of 100.
+3. The same flow fires for test notifications via `POST /notifications/test`.
+
+### API endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `PUT` | `/auth/profile/notification-token` | JWT | Register or update the device push token |
+| `POST` | `/notifications/test` | none | Send a test notification to a specific push token |
+
+### Registering a device token (Expo SDK example)
+
+```typescript
+import * as Notifications from "expo-notifications";
+
+const { status } = await Notifications.requestPermissionsAsync();
+if (status === "granted") {
+  const token = (await Notifications.getExpoPushTokenAsync()).data;
+  await fetch(`${BACKEND_URL}/auth/profile/notification-token`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ notificationToken: token }),
+  });
+}
+```
+
+### Alert notification payload
+
+```json
+{
+  "to": "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]",
+  "sound": "default",
+  "title": "Low Stock Alert",
+  "body": "Coffee beans is running low (3 remaining)",
+  "data": { "type": "alert", "itemId": 7 }
+}
+```
+
+### Removing a device token
+
+Pass `null` to unregister push notifications for a device (e.g. on logout):
+
+```typescript
+await fetch(`${BACKEND_URL}/auth/profile/notification-token`, {
+  method: "PUT",
+  headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+  body: JSON.stringify({ notificationToken: null }),
+});
+```
+
+---
+
 ## Troubleshooting
 
 ### Container does not start

--- a/backend/src/auth/dto/auth-response.dto.ts
+++ b/backend/src/auth/dto/auth-response.dto.ts
@@ -4,6 +4,9 @@ export class AuthResponseDto {
   @ApiProperty({ example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." })
   access_token: string;
 
+  @ApiProperty({ example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", description: "Opaque refresh token valid for 30 days; rotates on each use" })
+  refresh_token: string;
+
   @ApiProperty({ example: "bearer" })
   token_type: string;
 

--- a/backend/src/preferences/dto/update-preferences.dto.ts
+++ b/backend/src/preferences/dto/update-preferences.dto.ts
@@ -1,0 +1,22 @@
+/* eslint-disable prettier/prettier */
+import { ApiPropertyOptional } from "@nestjs/swagger";
+
+export class UpdatePreferencesDto {
+  @ApiPropertyOptional({ example: true, description: "Show welcome header on dashboard" })
+  showWelcomeHeader?: boolean;
+
+  @ApiPropertyOptional({ example: true, description: "Show stats cards on dashboard" })
+  showStatsCards?: boolean;
+
+  @ApiPropertyOptional({ example: true, description: "Show room distribution chart" })
+  showRoomDistribution?: boolean;
+
+  @ApiPropertyOptional({ example: true, description: "Show alerts per month chart" })
+  showAlertsPerMonth?: boolean;
+
+  @ApiPropertyOptional({ example: true, description: "Show inventory value widget" })
+  showInventoryValue?: boolean;
+
+  @ApiPropertyOptional({ example: true, description: "Show status distribution chart" })
+  showStatusDistribution?: boolean;
+}

--- a/backend/src/preferences/preferences.controller.ts
+++ b/backend/src/preferences/preferences.controller.ts
@@ -1,9 +1,14 @@
 /* eslint-disable prettier/prettier */
 import { Controller, Get, Put, Body, UseGuards, Request } from "@nestjs/common";
 import {
-  PreferencesService,
-  UpdatePreferencesDto,
-} from "./preferences.service";
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiBody,
+} from "@nestjs/swagger";
+import { PreferencesService } from "./preferences.service";
+import { UpdatePreferencesDto } from "./dto/update-preferences.dto";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 import { UserPreferences } from "@prisma/client";
 
@@ -16,12 +21,20 @@ interface AuthenticatedRequest extends Request {
   };
 }
 
+@ApiTags("Preferences")
+@ApiBearerAuth()
 @Controller("preferences")
 @UseGuards(JwtAuthGuard)
 export class PreferencesController {
   constructor(private preferencesService: PreferencesService) {}
 
   @Get()
+  @ApiOperation({ summary: "Get current user dashboard preferences" })
+  @ApiResponse({
+    status: 200,
+    description: "User preferences retrieved successfully",
+  })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
   async getUserPreferences(
     @Request() req: AuthenticatedRequest
   ): Promise<UserPreferences> {
@@ -29,6 +42,13 @@ export class PreferencesController {
   }
 
   @Put()
+  @ApiOperation({ summary: "Update current user dashboard preferences" })
+  @ApiBody({ type: UpdatePreferencesDto })
+  @ApiResponse({
+    status: 200,
+    description: "User preferences updated successfully",
+  })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
   async updateUserPreferences(
     @Request() req: AuthenticatedRequest,
     @Body() updates: UpdatePreferencesDto

--- a/backend/src/preferences/preferences.service.ts
+++ b/backend/src/preferences/preferences.service.ts
@@ -2,15 +2,8 @@
 import { Injectable } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
 import { UserPreferences } from "@prisma/client";
-
-export interface UpdatePreferencesDto {
-  showWelcomeHeader?: boolean;
-  showStatsCards?: boolean;
-  showRoomDistribution?: boolean;
-  showAlertsPerMonth?: boolean;
-  showInventoryValue?: boolean;
-  showStatusDistribution?: boolean;
-}
+export { UpdatePreferencesDto } from "./dto/update-preferences.dto";
+import { UpdatePreferencesDto } from "./dto/update-preferences.dto";
 
 @Injectable()
 export class PreferencesService {


### PR DESCRIPTION
## Summary

- Add `refresh_token` field with `@ApiProperty` to `AuthResponseDto` (30-day validity, auto-rotates on use)
- Extract `UpdatePreferencesDto` to dedicated DTO file with `@ApiPropertyOptional` on all six boolean fields
- Add full Swagger decorators to `PreferencesController` — tags, bearer auth, operations, body, and responses for both GET and PUT `/preferences`
- Add Mobile Integration section to README (§10) covering the Expo push notification flow

## Test plan

- [ ] Start the backend and open `/api` (Swagger UI) — verify all new fields and decorators appear correctly
- [ ] Check `AuthResponseDto` schema includes `refresh_token`
- [ ] Check `UpdatePreferencesDto` schema lists all boolean preference fields
- [ ] Check `PreferencesController` endpoints show operation summaries and response codes
- [ ] Review README §10 for accuracy against the actual notification flow

Closes FULA-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)